### PR TITLE
Viringbells

### DIFF
--- a/lib/processManager.js
+++ b/lib/processManager.js
@@ -5,14 +5,18 @@ var utils = require('./utils');
 var path  = require('path');
 var cp    = require('child_process');
 
-module.exports = processManager;
-
 process.env.PM2_SILENT = true;
-var pm2  = require('pm2');
+process.env.PM2_HOME   = process.env.PM2_HOME || path.join(__dirname, '..');
+process.env.PM2_HOME   = path.join(process.env.PM2_HOME, '.pm2');
+pm2  = require('pm2');
+
+module.exports = processManager;
 
 var filename = null;
 var appname = null;
 var root = null;
+
+var pm2;
 
 var pm = {
     error : null,
@@ -41,8 +45,6 @@ function processManager (app, config){
     pm.isMaster = true;
     pm.isWorker = false;
 
-    utils.mkdirSyncP(path.join(process.env.HOME, '.pm2/pids'));
-
     /**
      * @note  Since PM will start new processes for app
      *        and exit current process which is asynchronous
@@ -59,6 +61,8 @@ function processManager (app, config){
 }
 
 function prepareProcess () {
+    utils.mkdirSyncP(process.env.PM2_HOME);
+    utils.mkdirSyncP(path.join(process.env.PM2_HOME, 'pids'));
     if(path.basename(process.argv[0]) != 'node'){
         throw new Error("Node Bin name must be exactly <node> for PM2");
     }
@@ -66,27 +70,14 @@ function prepareProcess () {
     process.env.PATH = path.dirname(process.argv[0]) + ':' + process.env.PATH;
 }
 
-processManager.cmd = function (command, silent, callback) {
+processManager.cmd = function (command, callback) {
     prepareProcess();
-    if (!callback && silent instanceof Function) {
-        callback = silent;
-        silent = false;
-    }
     callback = callback || function () {
         process.exit(0);
     };
-    if (silent) {
-        var old_silent = process.env.PM2_SILENT;
-        process.env.PM2_SILENT = silent;
-        pm2cmd(command, function () {
-            process.env.PM2_SILENT = old_silent;
-            callback.apply(callback, arguments);
-        });
-    }
-    else {
-        var pm2path = path.join(__dirname, '../node_modules/pm2/bin/pm2');
-        cp.exec(process.argv[0] + ' ' + pm2path + ' ' + command, callback);
-    }
+    pm2cmd(command, function () {
+        callback.apply(callback, arguments);
+    });
     return processManager;
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lark-bootstrap",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "bootstrap lark by pm2",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
现在pm2的home目录（ _.pm2_ ）将不再放在 _~/_ 目录下，而是默认放在 _lark-bootstrap_ 的目录下。
通过修改 `process.env.PM2_HOME` 可以修改这个目录。